### PR TITLE
Check schema update permissions against only affected schema entries, not all schemas applied to page.

### DIFF
--- a/helper/update.php
+++ b/helper/update.php
@@ -69,7 +69,16 @@ class helper_plugin_structupdate_update extends helper_plugin_bureaucracy_action
                 $schemadata = [];
                 foreach($tables as $table) {
                     $schema = AccessTable::getPageAccess($table, $page);
-                    if(!$schema->getSchema()->isEditable()) {
+                    
+                    $schema_in_edit = false;
+                    foreach (array_keys($tosave) as $check_table) {
+                        if ($table == $check_table) {
+                            $schema_in_edit = true;
+                            break;
+                        }
+                    }
+
+                    if(!$schema->getSchema()->isEditable() && $schema_in_edit) {
                         throw new Exception("Schema $table is not editable");
                     }
                     $schemadata[$table] = [];


### PR DESCRIPTION
I have a use case where I have group specific edit roles assigned to each schema, and wanted to use this plugin with Bureaucracy to create an update form for the applicable schema. However; in the original version of this plugin the update would fail if the person submitting an update did not have access to any schema applied to the page. 

This change verifies the attempted update against the data it actually touches,  and only throws an exception if the update attempts to update a schema that the user does not have permissions for.